### PR TITLE
[Feat] Set caret on textArea when open tool window

### DIFF
--- a/src/main/java/com/quickmemo/plugin/action/OpenMemoAction.java
+++ b/src/main/java/com/quickmemo/plugin/action/OpenMemoAction.java
@@ -39,7 +39,13 @@ public class OpenMemoAction extends AnAction {
 
         project.getMessageBus().connect().subscribe(
                 ToolWindowManagerListener.TOPIC,
-                new ToolWindowManagerListener() {
+                getWindowManagerListener()
+        );
+        window.show(null);
+    }
+
+    private ToolWindowManagerListener getWindowManagerListener() {
+        return new ToolWindowManagerListener() {
             @Override
             public void toolWindowShown(@NotNull ToolWindow shownWindow) {
                 if (!WINDOW_NAME.equals(shownWindow.getId())) {
@@ -51,9 +57,7 @@ public class OpenMemoAction extends AnAction {
                     memoEditor.requestFocusOnEditor();
                 });
             }
-        });
-
-        window.show(null);
+        };
     }
 
     private @Nullable ToolWindow getWindow(Project project) {

--- a/src/main/java/com/quickmemo/plugin/action/OpenMemoAction.java
+++ b/src/main/java/com/quickmemo/plugin/action/OpenMemoAction.java
@@ -6,8 +6,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
-import com.quickmemo.plugin.window.MemoToolWindow;
-import com.quickmemo.plugin.window.MemoToolWindowFactory;
+import com.quickmemo.plugin.window.component.MemoEditor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,17 +37,19 @@ public class OpenMemoAction extends AnAction {
             return;
         }
 
-        project.getMessageBus().connect().subscribe(ToolWindowManagerListener.TOPIC, new ToolWindowManagerListener() {
+        project.getMessageBus().connect().subscribe(
+                ToolWindowManagerListener.TOPIC,
+                new ToolWindowManagerListener() {
             @Override
             public void toolWindowShown(@NotNull ToolWindow shownWindow) {
-                if (WINDOW_NAME.equals(shownWindow.getId())) {
-                    SwingUtilities.invokeLater(() -> {
-                        MemoToolWindow memoToolWindow = MemoToolWindowFactory.findMemoToolWindowInstance();
-                        if (memoToolWindow != null) {
-                            memoToolWindow.focusOnEditor();
-                        }
-                    });
+                if (!WINDOW_NAME.equals(shownWindow.getId())) {
+                    return;
                 }
+
+                SwingUtilities.invokeLater(() -> {
+                    MemoEditor memoEditor = MemoEditor.getInstance();
+                    memoEditor.requestFocusOnEditor();
+                });
             }
         });
 

--- a/src/main/java/com/quickmemo/plugin/action/OpenMemoAction.java
+++ b/src/main/java/com/quickmemo/plugin/action/OpenMemoAction.java
@@ -5,12 +5,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
-import com.quickmemo.plugin.window.component.MemoEditor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import javax.swing.*;
 
 public class OpenMemoAction extends AnAction {
 
@@ -32,32 +28,15 @@ public class OpenMemoAction extends AnAction {
             return;
         }
 
+        toggleWindow(window);
+    }
+
+    private void toggleWindow(ToolWindow window) {
         if (window.isVisible()) {
             window.hide();
             return;
         }
-
-        project.getMessageBus().connect().subscribe(
-                ToolWindowManagerListener.TOPIC,
-                getWindowManagerListener()
-        );
-        window.show(null);
-    }
-
-    private ToolWindowManagerListener getWindowManagerListener() {
-        return new ToolWindowManagerListener() {
-            @Override
-            public void toolWindowShown(@NotNull ToolWindow shownWindow) {
-                if (!WINDOW_NAME.equals(shownWindow.getId())) {
-                    return;
-                }
-
-                SwingUtilities.invokeLater(() -> {
-                    MemoEditor memoEditor = MemoEditor.getInstance();
-                    memoEditor.requestFocusOnEditor();
-                });
-            }
-        };
+        window.show();
     }
 
     private @Nullable ToolWindow getWindow(Project project) {

--- a/src/main/java/com/quickmemo/plugin/window/MemoToolWindow.java
+++ b/src/main/java/com/quickmemo/plugin/window/MemoToolWindow.java
@@ -51,7 +51,7 @@ public class MemoToolWindow {
     public MemoToolWindow(Project project) {
         this.memoService = getMemoService(project);
         this.content = new JPanel(new BorderLayout());
-        this.editor = new MemoEditor();
+        this.editor = MemoEditor.getInstance();
         this.memoList = new MemoList();
         this.actionManager = new MemoActionManager(this);
         this.centerPanel = new JPanel(new CardLayout());
@@ -281,13 +281,5 @@ public class MemoToolWindow {
 
     public CurrentMemo getCurrentMemo() {
         return currentMemo;
-    }
-
-    public void focusOnEditor() {
-        SwingUtilities.invokeLater(() -> {
-            CardLayout cardLayout = (CardLayout) centerPanel.getLayout();
-            cardLayout.show(centerPanel, LAYOUT_MEMO);
-            editor.requestFocusOnEditor();
-        });
     }
 }

--- a/src/main/java/com/quickmemo/plugin/window/MemoToolWindow.java
+++ b/src/main/java/com/quickmemo/plugin/window/MemoToolWindow.java
@@ -62,14 +62,11 @@ public class MemoToolWindow {
     }
 
     private void initializeLayout() {
-        // 중앙 패널 설정
         centerPanel.add(editor, LAYOUT_MEMO);
         centerPanel.add(EMPTY_LABEL, LAYOUT_EMPTY);
 
-        // 툴바 설정
         MemoToolbar toolbar = MemoToolbar.initializeWithActionManager(actionManager, content);
         
-        // 전체 레이아웃 구성
         content.add(toolbar, BorderLayout.NORTH);
         content.add(centerPanel, BorderLayout.CENTER);
     }
@@ -117,6 +114,7 @@ public class MemoToolWindow {
         } else {
             showEmptyState();
         }
+        editor.requestFocusOnEditor();
     }
 
     private static JBLabel getEmptyLabel() {
@@ -277,11 +275,19 @@ public class MemoToolWindow {
         }
     }
 
-    public JPanel getContent() {
+    public JComponent getContent() {
         return content;
     }
 
     public CurrentMemo getCurrentMemo() {
         return currentMemo;
+    }
+
+    public void focusOnEditor() {
+        SwingUtilities.invokeLater(() -> {
+            CardLayout cardLayout = (CardLayout) centerPanel.getLayout();
+            cardLayout.show(centerPanel, LAYOUT_MEMO);
+            editor.requestFocusOnEditor();
+        });
     }
 }

--- a/src/main/java/com/quickmemo/plugin/window/MemoToolWindowFactory.java
+++ b/src/main/java/com/quickmemo/plugin/window/MemoToolWindowFactory.java
@@ -14,12 +14,17 @@ import java.awt.*;
 public class MemoToolWindowFactory implements ToolWindowFactory {
     private static final int DEFAULT_SIZE = 400;
     private static final Dimension DEFAULT_DIMENSION_SIZE = new Dimension(DEFAULT_SIZE, DEFAULT_SIZE);
+    private static MemoToolWindow memoToolWindow;
+
+    public static MemoToolWindow findMemoToolWindowInstance() {
+        return memoToolWindow;
+    }
 
     @Override
     public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
         toolWindow.setType(ToolWindowType.FLOATING, null);
 
-        MemoToolWindow memoToolWindow = new MemoToolWindow(project);
+        memoToolWindow = new MemoToolWindow(project);
         JComponent component = memoToolWindow.getContent();
 
         component.setPreferredSize(DEFAULT_DIMENSION_SIZE);

--- a/src/main/java/com/quickmemo/plugin/window/MemoToolWindowFactory.java
+++ b/src/main/java/com/quickmemo/plugin/window/MemoToolWindowFactory.java
@@ -14,17 +14,12 @@ import java.awt.*;
 public class MemoToolWindowFactory implements ToolWindowFactory {
     private static final int DEFAULT_SIZE = 400;
     private static final Dimension DEFAULT_DIMENSION_SIZE = new Dimension(DEFAULT_SIZE, DEFAULT_SIZE);
-    private static MemoToolWindow memoToolWindow;
-
-    public static MemoToolWindow findMemoToolWindowInstance() {
-        return memoToolWindow;
-    }
 
     @Override
     public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
         toolWindow.setType(ToolWindowType.FLOATING, null);
 
-        memoToolWindow = new MemoToolWindow(project);
+        MemoToolWindow memoToolWindow = new MemoToolWindow(project);
         JComponent component = memoToolWindow.getContent();
 
         component.setPreferredSize(DEFAULT_DIMENSION_SIZE);

--- a/src/main/java/com/quickmemo/plugin/window/MemoToolWindowFactory.java
+++ b/src/main/java/com/quickmemo/plugin/window/MemoToolWindowFactory.java
@@ -4,8 +4,10 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.openapi.wm.ToolWindowType;
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
+import com.quickmemo.plugin.window.component.MemoEditor;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -14,6 +16,7 @@ import java.awt.*;
 public class MemoToolWindowFactory implements ToolWindowFactory {
     private static final int DEFAULT_SIZE = 400;
     private static final Dimension DEFAULT_DIMENSION_SIZE = new Dimension(DEFAULT_SIZE, DEFAULT_SIZE);
+    public static final String WINDOW_NAME = "QuickMemo";
 
     @Override
     public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
@@ -29,6 +32,8 @@ public class MemoToolWindowFactory implements ToolWindowFactory {
                 .createContent(component, "", false);
         toolWindow.getContentManager().addContent(content);
 
+        addEditorOpenListener(project);
+
         SwingUtilities.invokeLater(() -> {
             Timer timer = new Timer(100, event -> {
                 Window win = SwingUtilities.getWindowAncestor(component);
@@ -42,5 +47,28 @@ public class MemoToolWindowFactory implements ToolWindowFactory {
             timer.setRepeats(false);
             timer.start();
         });
+    }
+
+    private void addEditorOpenListener(@NotNull Project project) {
+        project.getMessageBus().connect().subscribe(
+                ToolWindowManagerListener.TOPIC,
+                getWindowManagerListener()
+        );
+    }
+
+    private ToolWindowManagerListener getWindowManagerListener() {
+        return new ToolWindowManagerListener() {
+            @Override
+            public void toolWindowShown(@NotNull ToolWindow shownWindow) {
+                if (!WINDOW_NAME.equals(shownWindow.getId())) {
+                    return;
+                }
+
+                SwingUtilities.invokeLater(() -> {
+                    MemoEditor memoEditor = MemoEditor.getInstance();
+                    memoEditor.requestFocusOnEditor();
+                });
+            }
+        };
     }
 }

--- a/src/main/java/com/quickmemo/plugin/window/component/MemoEditor.java
+++ b/src/main/java/com/quickmemo/plugin/window/component/MemoEditor.java
@@ -79,10 +79,6 @@ public class MemoEditor extends JPanel {
 
     public void requestFocusOnEditor() {
         textArea.setCaretPosition(textArea.getText().length());
-        textArea.setEditable(true);
-        textArea.setEnabled(true);
-        textArea.setFocusable(true);
         textArea.grabFocus();
-        textArea.requestFocusInWindow();
     }
 }

--- a/src/main/java/com/quickmemo/plugin/window/component/MemoEditor.java
+++ b/src/main/java/com/quickmemo/plugin/window/component/MemoEditor.java
@@ -12,6 +12,7 @@ import java.awt.*;
 import java.awt.event.MouseWheelEvent;
 
 public class MemoEditor extends JPanel {
+    private static MemoEditor instance;
     private final JBTextArea textArea;
 
     private static final int TOP_BOTTOM_PADDING = 8;
@@ -19,7 +20,14 @@ public class MemoEditor extends JPanel {
     private static final JBEmptyBorder INPUT_AREA_PADDING = JBUI.Borders
             .empty(TOP_BOTTOM_PADDING, LEFT_RIGHT_PADDING);
 
-    public MemoEditor() {
+    public static MemoEditor getInstance() {
+        if (instance == null) {
+            instance = new MemoEditor();
+        }
+        return instance;
+    }
+
+    private MemoEditor() {
         super(new BorderLayout());
         textArea = createTextArea();
         addMouseWheelListener(textArea);
@@ -33,6 +41,7 @@ public class MemoEditor extends JPanel {
 
     private JBTextArea createTextArea() {
         JBTextArea area = new JBTextArea();
+        area.setFont(area.getFont().deriveFont((float) JBUI.scale(14)));
         area.setLineWrap(true);
         area.setWrapStyleWord(true);
         area.setBorder(INPUT_AREA_PADDING);

--- a/src/main/java/com/quickmemo/plugin/window/component/MemoEditor.java
+++ b/src/main/java/com/quickmemo/plugin/window/component/MemoEditor.java
@@ -69,6 +69,11 @@ public class MemoEditor extends JPanel {
     }
 
     public void requestFocusOnEditor() {
-        textArea.requestFocus();
+        textArea.setCaretPosition(textArea.getText().length());
+        textArea.setEditable(true);
+        textArea.setEnabled(true);
+        textArea.setFocusable(true);
+        textArea.grabFocus();
+        textArea.requestFocusInWindow();
     }
 }


### PR DESCRIPTION
메모에서 focus를 해제한 뒤
메모를 껐다가 다시 키면 바로 입력가능하지 않아서 불편했다.

-> 이제 Open 단축키 입력시 마지막으로 켜둔 메모의 마지막 글자에 커서가 나타나서, 즉시 입력 가능하다. 

1. MemoEditor를 싱글톤화
2. ToolWindow가 Shown 될 때, (보여질 때) Caret이 텍스트 끝에 set 되도록 변경