### PR TITLE
[Feat] 에디터 폰트 이쁜(?) 폰트로 변경

### DIFF
--- a/src/main/java/com/quickmemo/plugin/ui/editor/FontHolder.java
+++ b/src/main/java/com/quickmemo/plugin/ui/editor/FontHolder.java
@@ -10,7 +10,8 @@ import java.util.Arrays;
 import java.util.List;
 
 public class FontHolder {
-    private static final Font DEFAULT_GLOBAL = new Font(Font.MONOSPACED, Font.PLAIN, 14);
+    private static final String JETBRAINS_MONO = "JetBrains Mono";
+    private static final Font DEFAULT_GLOBAL = new Font(JETBRAINS_MONO, Font.PLAIN, 14);
     private static final List<String> KOREAN_FONTS = List.of(
             // for macOS
             "Apple SD GothicNeo Neo",
@@ -26,19 +27,18 @@ public class FontHolder {
     );
 
     public static final char VALIDATE_KOREAN_CHAR = '한';
+    public static final String FONT_SPEC_FORMAT = "%s, %s-PLAIN-%d";
 
     public Font getEditorFont() {
         Font editorFont = getIDEFont();
 
         // find korean for korean users..
         String koreanFont = getKoreanFont();
-        String fontFamily = editorFont.getFamily() + ", " + koreanFont;
-        return Font.decode(fontFamily + "-PLAIN-" + editorFont.getSize());
+        return getFont(editorFont, koreanFont);
     }
 
     private String getKoreanFont() {
         String koreanFont =  findKoreanFont();
-        System.out.println("[DEBUG] Korean font: " + koreanFont);
         if (koreanFont != null) {
             return koreanFont;
         }
@@ -92,5 +92,15 @@ public class FontHolder {
     private boolean canDisplay(String koreanFont) {
         Font font = new Font(koreanFont, Font.PLAIN, 1);
         return font.canDisplay(VALIDATE_KOREAN_CHAR);
+    }
+
+    private Font getFont(Font editorFont, String koreanFont) {
+        String fontSpec = String.format(FONT_SPEC_FORMAT,
+                editorFont.getFamily(),
+                koreanFont,
+                editorFont.getSize()
+        );
+
+        return Font.decode(fontSpec);
     }
 }

--- a/src/main/java/com/quickmemo/plugin/ui/editor/FontHolder.java
+++ b/src/main/java/com/quickmemo/plugin/ui/editor/FontHolder.java
@@ -4,25 +4,26 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.editor.colors.EditorColorsScheme;
 import com.intellij.openapi.editor.colors.EditorFontType;
-import com.intellij.util.ui.UIUtil;
 
 import java.awt.*;
+import java.util.Arrays;
+import java.util.List;
 
 public class FontHolder {
     private static final Font DEFAULT_GLOBAL = new Font(Font.MONOSPACED, Font.PLAIN, 14);
-    public static final String DEFAULT_KOREAN_FONT = Font.DIALOG;
-    private static final String[] KOREAN_FONTS = {
+    private static final List<String> KOREAN_FONTS = List.of(
             // for macOS
             "Apple SD GothicNeo Neo",
             "AppleSDGothicNeo-Regular",
 
             // for Window guys
-            "Malgun Gothic",
+            "D2Coding",
+            "맑은 고딕",
 
             // Linux
             "NotoSansCJK-Regular",
             "Noto Sans CJK KR"
-    };
+    );
 
     public static final char VALIDATE_KOREAN_CHAR = '한';
 
@@ -30,46 +31,41 @@ public class FontHolder {
         Font editorFont = getIDEFont();
 
         // find korean for korean users..
-        String koreanFont = findKoreanFont();
-
+        String koreanFont = getKoreanFont();
         String fontFamily = editorFont.getFamily() + ", " + koreanFont;
         return Font.decode(fontFamily + "-PLAIN-" + editorFont.getSize());
     }
 
+    private String getKoreanFont() {
+        String koreanFont =  findKoreanFont();
+        System.out.println("[DEBUG] Korean font: " + koreanFont);
+        if (koreanFont != null) {
+            return koreanFont;
+        }
+        return DEFAULT_GLOBAL.getFamily();
+    }
+
     private String findKoreanFont() {
         if (KOREAN_FONTS == null) {
-            return DEFAULT_KOREAN_FONT;
+            return DEFAULT_GLOBAL.getFamily();
         }
 
-        for (String koreanFont : KOREAN_FONTS) {
-            try {
-                if (canDisplay(koreanFont)) {
-                    return koreanFont;
-                }
-            } catch (Exception e) {
-                return getDefaultKoreanFont();
-            }
+        String installedKoreanFont = findInstalledKoreanFont();
+        if (installedKoreanFont != null) {
+            return installedKoreanFont;
         }
-
-        return getDefaultKoreanFont();
+        return DEFAULT_GLOBAL.getFamily();
     }
 
-    private String getDefaultKoreanFont() {
-        try {
-            Font ideFont = UIUtil.getFontWithFallback(DEFAULT_KOREAN_FONT, Font.PLAIN, 1);
-            if (ideFont.canDisplay(VALIDATE_KOREAN_CHAR)) {
-                return ideFont.getFamily();
-            } else {
-                return DEFAULT_KOREAN_FONT;
-            }
-        } catch (Exception e) {
-            return DEFAULT_KOREAN_FONT;
-        }
-    }
-
-    private boolean canDisplay(String koreanFont) {
-        Font font = new Font(koreanFont, Font.PLAIN, 1);
-        return font.canDisplay(VALIDATE_KOREAN_CHAR);
+    private String findInstalledKoreanFont() {
+        GraphicsEnvironment graphicsEnvironment = GraphicsEnvironment.getLocalGraphicsEnvironment();
+        String[] availableFontFamilyNames = graphicsEnvironment.getAvailableFontFamilyNames();
+        List<String> installedFonts = Arrays.asList(availableFontFamilyNames);
+        return installedFonts.stream()
+                .filter(KOREAN_FONTS::contains)
+                .filter(this::canDisplay)
+                .findFirst()
+                .orElse(getGlobalFont().getFamily());
     }
 
     private Font getIDEFont() {
@@ -91,5 +87,10 @@ public class FontHolder {
         }
         EditorColorsScheme globalScheme = colorsManager.getGlobalScheme();
         return globalScheme.getFont(EditorFontType.PLAIN);
+    }
+
+    private boolean canDisplay(String koreanFont) {
+        Font font = new Font(koreanFont, Font.PLAIN, 1);
+        return font.canDisplay(VALIDATE_KOREAN_CHAR);
     }
 }

--- a/src/main/java/com/quickmemo/plugin/ui/editor/FontHolder.java
+++ b/src/main/java/com/quickmemo/plugin/ui/editor/FontHolder.java
@@ -1,0 +1,95 @@
+package com.quickmemo.plugin.ui.editor;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.colors.EditorColorsManager;
+import com.intellij.openapi.editor.colors.EditorColorsScheme;
+import com.intellij.openapi.editor.colors.EditorFontType;
+import com.intellij.util.ui.UIUtil;
+
+import java.awt.*;
+
+public class FontHolder {
+    private static final Font DEFAULT_GLOBAL = new Font(Font.MONOSPACED, Font.PLAIN, 14);
+    public static final String DEFAULT_KOREAN_FONT = Font.DIALOG;
+    private static final String[] KOREAN_FONTS = {
+            // for macOS
+            "Apple SD GothicNeo Neo",
+            "AppleSDGothicNeo-Regular",
+
+            // for Window guys
+            "Malgun Gothic",
+
+            // Linux
+            "NotoSansCJK-Regular",
+            "Noto Sans CJK KR"
+    };
+
+    public static final char VALIDATE_KOREAN_CHAR = '한';
+
+    public Font getEditorFont() {
+        Font editorFont = getIDEFont();
+
+        // find korean for korean users..
+        String koreanFont = findKoreanFont();
+
+        String fontFamily = editorFont.getFamily() + ", " + koreanFont;
+        return Font.decode(fontFamily + "-PLAIN-" + editorFont.getSize());
+    }
+
+    private String findKoreanFont() {
+        if (KOREAN_FONTS == null) {
+            return DEFAULT_KOREAN_FONT;
+        }
+
+        for (String koreanFont : KOREAN_FONTS) {
+            try {
+                if (canDisplay(koreanFont)) {
+                    return koreanFont;
+                }
+            } catch (Exception e) {
+                return getDefaultKoreanFont();
+            }
+        }
+
+        return getDefaultKoreanFont();
+    }
+
+    private String getDefaultKoreanFont() {
+        try {
+            Font ideFont = UIUtil.getFontWithFallback(DEFAULT_KOREAN_FONT, Font.PLAIN, 1);
+            if (ideFont.canDisplay(VALIDATE_KOREAN_CHAR)) {
+                return ideFont.getFamily();
+            } else {
+                return DEFAULT_KOREAN_FONT;
+            }
+        } catch (Exception e) {
+            return DEFAULT_KOREAN_FONT;
+        }
+    }
+
+    private boolean canDisplay(String koreanFont) {
+        Font font = new Font(koreanFont, Font.PLAIN, 1);
+        return font.canDisplay(VALIDATE_KOREAN_CHAR);
+    }
+
+    private Font getIDEFont() {
+        if (ApplicationManager.getApplication() == null) {
+            return DEFAULT_GLOBAL;
+        }
+
+        try {
+            return getGlobalFont();
+        } catch (Exception e) {
+            return DEFAULT_GLOBAL;
+        }
+    }
+
+    private Font getGlobalFont() {
+        EditorColorsManager colorsManager = EditorColorsManager.getInstance();
+        if (colorsManager == null) {
+            return DEFAULT_GLOBAL;
+        }
+        EditorColorsScheme globalScheme = colorsManager.getGlobalScheme();
+        return globalScheme.getFont(EditorFontType.PLAIN);
+    }
+}

--- a/src/main/java/com/quickmemo/plugin/ui/editor/MemoEditor.java
+++ b/src/main/java/com/quickmemo/plugin/ui/editor/MemoEditor.java
@@ -11,13 +11,20 @@ import java.awt.*;
 import java.awt.event.MouseWheelEvent;
 
 public class MemoEditor extends JPanel {
-    private static final MemoEditor INSTANCE = new MemoEditor();
+    private static volatile MemoEditor INSTANCE;
     private final JBTextArea textArea;
 
     private static final int TOP_BOTTOM_PADDING = 8;
     private static final int LEFT_RIGHT_PADDING = 10;
 
     public static MemoEditor getInstance() {
+        if (INSTANCE == null) {
+            synchronized (MemoEditor.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = new MemoEditor();
+                }
+            }
+        }
         return INSTANCE;
     }
 

--- a/src/main/java/com/quickmemo/plugin/ui/editor/MemoEditor.java
+++ b/src/main/java/com/quickmemo/plugin/ui/editor/MemoEditor.java
@@ -36,7 +36,10 @@ public class MemoEditor extends JPanel {
 
     private JBTextArea createTextArea() {
         JBTextArea area = new JBTextArea();
-        area.setFont(area.getFont().deriveFont((float) JBUI.scale(14)));
+
+        FontHolder fontHolder = new FontHolder();
+        area.setFont(fontHolder.getEditorFont());
+
         area.setLineWrap(true);
         area.setWrapStyleWord(true);
         area.setMargin(JBUI.insets(TOP_BOTTOM_PADDING, LEFT_RIGHT_PADDING));


### PR DESCRIPTION
1. 영어의 경우 jetbrain mono를 기본적으로 사용한다.
2. 한글의 경우 OS별로 괜찮은(?) 글꼴이 제공되므로 우선적으로 있는지 확인하고, 
- 없으면 에디터에 설정한 한글 글꼴로 설정
- 이것도 없으면 jetbrain mono



## ~~찝찝한 점..~~
~~유저가 에디터에 설정한 한글 글꼴이 이쁠까? 하는 의문은 있음~~
~~IDE 특성상 영어를 칠 일이 압도적이기 떄문에 유저가 한글 글꼴은 신경쓰지 않을 것 같음~~

## 찝찝해서 그냥 고쳤다.. 
- 미리 설정해둔 괜찮은 글꼴이 없으면 jetbrain mono로 통일